### PR TITLE
Reduce resource requirements of Consul

### DIFF
--- a/blueprint.yml
+++ b/blueprint.yml
@@ -7,8 +7,8 @@ placement:
 
 instance:
   public_ip: True
-  memory: 1GB
-  cpus: 1
+  memory: 0.25GB
+  cpus: 0.1
   gpu: false
   disks:
     - size: 8GB

--- a/blueprint_fixture.py
+++ b/blueprint_fixture.py
@@ -11,7 +11,7 @@ from cloudless.testutils.fixture import BlueprintTestInterface, SetupInfo
 from cloudless.types.networking import CidrBlock
 
 RETRY_DELAY = float(10.0)
-RETRY_COUNT = int(6)
+RETRY_COUNT = int(10)
 
 class BlueprintTest(BlueprintTestInterface):
     """


### PR DESCRIPTION
Considering the use case as a configuration store, make the default
resources as small as possible.